### PR TITLE
Accept multiple env variables

### DIFF
--- a/.license_template
+++ b/.license_template
@@ -1,3 +1,0 @@
-// Copyright {20\d{2}(-20\d{2})?} Tauri Programme within The Commons Conservancy
-// SPDX-License-Identifier: Apache-2.0
-// SPDX-License-Identifier: MIT

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -14,4 +14,3 @@ force_explicit_abi = true
 # normalize_comments = true
 normalize_doc_attributes = true
 # wrap_comments = true
-license_template_path = ".license_template"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,61 +11,62 @@ pub enum Error {
   EchoFailed(String),
 }
 
-
 /// Reads the shell configuration to properly set all given environment variables.
-#[cfg(not(windows))]
+///
+/// ## Platform-specific
+///
+/// - **Windows**: Does nothing as the environment variables are already set.
 pub fn fix_vars(vars: &[&str]) -> std::result::Result<(), Error> {
-  let default_shell = if cfg!(target_os = "macos") {
-    "/bin/zsh"
-  } else {
-    "/bin/sh"
-  };
-  let shell = std::env::var("SHELL").unwrap_or_else(|_| default_shell.into());
+  #[cfg(windows)]
+  {
+    let _vars = vars;
+    return Ok(());
+  }
+  #[cfg(not(windows))]
+  {
+    let default_shell = if cfg!(target_os = "macos") {
+      "/bin/zsh"
+    } else {
+      "/bin/sh"
+    };
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| default_shell.into());
 
-  let out = std::process::Command::new(shell)
-    .arg("-ilc")
-    .arg("echo -n \"_SHELL_ENV_DELIMITER_\"; env; echo -n \"_SHELL_ENV_DELIMITER_\"; exit")
-    // Disables Oh My Zsh auto-update thing that can block the process.
-    .env("DISABLE_AUTO_UPDATE", "true")
-    .output()
-    .map_err(Error::Shell)?;
+    let out = std::process::Command::new(shell)
+      .arg("-ilc")
+      .arg("echo -n \"_SHELL_ENV_DELIMITER_\"; env; echo -n \"_SHELL_ENV_DELIMITER_\"; exit")
+      // Disables Oh My Zsh auto-update thing that can block the process.
+      .env("DISABLE_AUTO_UPDATE", "true")
+      .output()
+      .map_err(Error::Shell)?;
 
-  if out.status.success() {
-    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    let env = stdout.split("_SHELL_ENV_DELIMITER_").nth(1).unwrap();
-    for line in String::from_utf8_lossy(&strip_ansi_escapes::strip(env)?)
-      .split('\n')
-      .filter(|l| !l.is_empty())
-    {
-      let mut s = line.split('=');
-      if let (Some(var), Some(value)) = (s.next(), s.next()) {
-        if vars.contains(&var) {
-          std::env::set_var(var, value);
+    if out.status.success() {
+      let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+      let env = stdout.split("_SHELL_ENV_DELIMITER_").nth(1).unwrap();
+      for line in String::from_utf8_lossy(&strip_ansi_escapes::strip(env)?)
+        .split('\n')
+        .filter(|l| !l.is_empty())
+      {
+        let mut s = line.split('=');
+        if let (Some(var), Some(value)) = (s.next(), s.next()) {
+          if vars.contains(&var) {
+            std::env::set_var(var, value);
+          }
         }
       }
+      Ok(())
+    } else {
+      Err(Error::EchoFailed(
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+      ))
     }
-    Ok(())
-  } else {
-    Err(Error::EchoFailed(
-      String::from_utf8_lossy(&out.stderr).into_owned(),
-    ))
   }
 }
 
 /// Reads the shell configuration to properly set the PATH environment variable.
-#[cfg(not(windows))]
+///
+/// ## Platform-specific
+///
+/// - **Windows**: Does nothing as the environment variables are already set.
 pub fn fix() -> std::result::Result<(), Error> {
   fix_vars(&["PATH"])
-}
-
-/// Do nothing on Windows as the environment variables are already set.
-#[cfg(windows)]
-pub fn fix_vars(vars: &[&str]) -> std::result::Result<(), Error> {
-  Ok(())
-}
-
-/// Do nothing on Windows as the PATH environment variable is already set.
-#[cfg(windows)]
-pub fn fix() -> std::result::Result<(), Error> {
-  Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,12 @@ pub fn fix() -> std::result::Result<(), Error> {
   fix_vars(&["PATH"])
 }
 
+/// Do nothing on Windows as the environment variables are already set.
+#[cfg(windows)]
+pub fn fix_vars(vars: &[&str]) -> std::result::Result<(), Error> {
+  Ok(())
+}
+
 /// Do nothing on Windows as the PATH environment variable is already set.
 #[cfg(windows)]
 pub fn fix() -> std::result::Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,10 @@ pub fn fix() -> std::result::Result<(), Error> {
           std::env::set_var("PATH", value);
           break;
         }
+        if var == "KUBECONFIG" {
+          std::env::set_var("KUBECONFIG", value);
+          break;
+        }
       }
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,11 +40,9 @@ pub fn fix() -> std::result::Result<(), Error> {
       if let (Some(var), Some(value)) = (s.next(), s.next()) {
         if var == "PATH" {
           std::env::set_var("PATH", value);
-          break;
         }
         if var == "KUBECONFIG" {
           std::env::set_var("KUBECONFIG", value);
-          break;
         }
       }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,10 @@ pub enum Error {
   EchoFailed(String),
 }
 
-/// Reads the shell configuration to properly set the PATH environment variable.
+
+/// Reads the shell configuration to properly set all given environment variables.
 #[cfg(not(windows))]
-pub fn fix() -> std::result::Result<(), Error> {
+pub fn fix_vars(vars: &[&str]) -> std::result::Result<(), Error> {
   let default_shell = if cfg!(target_os = "macos") {
     "/bin/zsh"
   } else {
@@ -38,11 +39,8 @@ pub fn fix() -> std::result::Result<(), Error> {
     {
       let mut s = line.split('=');
       if let (Some(var), Some(value)) = (s.next(), s.next()) {
-        if var == "PATH" {
-          std::env::set_var("PATH", value);
-        }
-        if var == "KUBECONFIG" {
-          std::env::set_var("KUBECONFIG", value);
+        if vars.contains(&var) {
+          std::env::set_var(var, value);
         }
       }
     }
@@ -52,6 +50,12 @@ pub fn fix() -> std::result::Result<(), Error> {
       String::from_utf8_lossy(&out.stderr).into_owned(),
     ))
   }
+}
+
+/// Reads the shell configuration to properly set the PATH environment variable.
+#[cfg(not(windows))]
+pub fn fix() -> std::result::Result<(), Error> {
+  fix_vars(&["PATH"])
 }
 
 /// Do nothing on Windows as the PATH environment variable is already set.


### PR DESCRIPTION
Hey there. I'm working on an app where most users will have other variables defined in shell profile files other than PATH, which is not being picked up by the App when launched via UI.

This PR essentially adds a new function that accepts multiple env variables