### PR TITLE
Remove ? operator according to strip_ansi_escapes change.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub fn fix_vars(vars: &[&str]) -> std::result::Result<(), Error> {
         .split("_SHELL_ENV_DELIMITER_")
         .nth(1)
         .ok_or_else(|| Error::InvalidOutput(stdout.clone()))?;
-      for line in String::from_utf8_lossy(&strip_ansi_escapes::strip(env)?)
+      for line in String::from_utf8_lossy(&strip_ansi_escapes::strip(env))
         .split('\n')
         .filter(|l| !l.is_empty())
       {


### PR DESCRIPTION
This fixes the following compilation error.

```
error[E0277]: the `?` operator can only be applied to values that implement `Try`
  --> src/lib.rs:50:44
   |
50 |       for line in String::from_utf8_lossy(&strip_ansi_escapes::strip(env)?)
   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `Vec<u8>`
   |
   = help: the trait `Try` is not implemented for `Vec<u8>`

error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
  --> src/lib.rs:50:44
   |
50 |       for line in String::from_utf8_lossy(&strip_ansi_escapes::strip(env)?)
   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
   |
   = help: the trait `Sized` is not implemented for `[u8]`
   = note: all local variables must have a statically known size
   = help: unsized locals are gated as an unstable feature

error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
  --> src/lib.rs:50:74
   |
50 |       for line in String::from_utf8_lossy(&strip_ansi_escapes::strip(env)?)
   |                                                                          ^ doesn't have a size known at compile-time
   |
   = help: the trait `Sized` is not implemented for `[u8]`
note: required by a bound in `Break`
  --> /home/falsetru/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/control_flow.rs:85:25
   |
85 | pub enum ControlFlow<B, C = ()> {
   |                         ^^^^^^ required by this bound in `Break`
...
93 |     Break(B),
   |     ----- required by a bound in this variant

For more information about this error, try `rustc --explain E0277`.
error: could not compile `fix-path-env` (lib) due to 3 previous errors
```

The error was caused by strip_ascii_escape change. `strip_ansi_escapes::strip` now returns `Vec<u8>` instead of `Result<Vec<u8>>`. (https://github.com/luser/strip-ansi-escapes/pull/11/files)