### PR TITLE
set CWD on Command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 thiserror = "1"
+home = "0.5"
 
 [target."cfg(not(target_os = \"windows\"))".dependencies]
 strip-ansi-escapes = "0.2"

--- a/examples/shell.rs
+++ b/examples/shell.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use fix_path_env::fix_all_vars;
+use fix_path_env::fix;
 
 fn main() {
-  if let Err(e) = fix_all_vars() {
+  if let Err(e) = fix() {
     println!("{}", e);
+  } else {
+    println!("PATH: {}", std::env::var("PATH").unwrap());
   }
 }

--- a/examples/shell.rs
+++ b/examples/shell.rs
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use fix_path_env::fix;
+use fix_path_env::fix_all_vars;
 
 fn main() {
-  if let Err(e) = fix() {
+  if let Err(e) = fix_all_vars() {
     println!("{}", e);
-  } else {
-    println!("PATH: {}", std::env::var("PATH").unwrap());
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub fn fix_vars(vars: &[&str]) -> std::result::Result<FixResults, Error> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| default_shell.into());
 
     let out = std::process::Command::new(shell.clone())
+      .current_dir(home::home_dir().unwrap_or_default())
       .arg("-ilc")
       .arg("echo -n \"_SHELL_ENV_DELIMITER_\"; env; echo -n \"_SHELL_ENV_DELIMITER_\"; exit")
       // Disables Oh My Zsh auto-update thing that can block the process.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,17 +13,12 @@ pub enum Error {
   EchoFailed(String),
 }
 
-pub struct FixResults {
-  pub shell: String,
-  pub env_vars: Vec<String>,
-}
-
 /// Reads the shell configuration to properly set all given environment variables.
 ///
 /// ## Platform-specific
 ///
 /// - **Windows**: Does nothing as the environment variables are already set.
-pub fn fix_vars(vars: &[&str]) -> std::result::Result<FixResults, Error> {
+pub fn fix_vars(vars: &[&str]) -> std::result::Result<(), Error> {
   #[cfg(windows)]
   {
     let _ = vars;
@@ -39,7 +34,7 @@ pub fn fix_vars(vars: &[&str]) -> std::result::Result<FixResults, Error> {
     };
     let shell = std::env::var("SHELL").unwrap_or_else(|_| default_shell.into());
 
-    let out = std::process::Command::new(shell.clone())
+    let out = std::process::Command::new(shell)
       .current_dir(home::home_dir().unwrap_or_default())
       .arg("-ilc")
       .arg("echo -n \"_SHELL_ENV_DELIMITER_\"; env; echo -n \"_SHELL_ENV_DELIMITER_\"; exit")
@@ -49,8 +44,6 @@ pub fn fix_vars(vars: &[&str]) -> std::result::Result<FixResults, Error> {
       .map_err(Error::Shell)?;
 
     if out.status.success() {
-      let mut results = FixResults { shell, env_vars: vec![] };
-
       let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
       let env = stdout
         .split("_SHELL_ENV_DELIMITER_")
@@ -63,12 +56,11 @@ pub fn fix_vars(vars: &[&str]) -> std::result::Result<FixResults, Error> {
         let mut s = line.splitn(2, '=');
         if let (Some(var), Some(value)) = (s.next(), s.next()) {
           if vars.is_empty() || vars.contains(&var) {
-            results.env_vars.push(var.into());
             std::env::set_var(var, value);
           }
         }
       }
-      Ok(results)
+      Ok(())
     } else {
       Err(Error::EchoFailed(
         String::from_utf8_lossy(&out.stderr).into_owned(),
@@ -82,7 +74,7 @@ pub fn fix_vars(vars: &[&str]) -> std::result::Result<FixResults, Error> {
 /// ## Platform-specific
 ///
 /// - **Windows**: Does nothing as the environment variables are already set.
-pub fn fix() -> std::result::Result<FixResults, Error> {
+pub fn fix() -> std::result::Result<(), Error> {
   fix_vars(&["PATH"])
 }
 
@@ -91,6 +83,6 @@ pub fn fix() -> std::result::Result<FixResults, Error> {
 /// ## Platform-specific
 ///
 /// - **Windows**: Does nothing as the environment variables are already set.
-pub fn fix_all_vars() -> std::result::Result<FixResults, Error> {
+pub fn fix_all_vars() -> std::result::Result<(), Error> {
   fix_vars(&[])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,14 +34,18 @@ pub fn fix_vars(vars: &[&str]) -> std::result::Result<(), Error> {
     };
     let shell = std::env::var("SHELL").unwrap_or_else(|_| default_shell.into());
 
-    let out = std::process::Command::new(shell)
-      .current_dir(home::home_dir().unwrap_or_default())
-      .arg("-ilc")
+    let mut cmd = std::process::Command::new(shell);
+
+    cmd.arg("-ilc")
       .arg("echo -n \"_SHELL_ENV_DELIMITER_\"; env; echo -n \"_SHELL_ENV_DELIMITER_\"; exit")
       // Disables Oh My Zsh auto-update thing that can block the process.
-      .env("DISABLE_AUTO_UPDATE", "true")
-      .output()
-      .map_err(Error::Shell)?;
+      .env("DISABLE_AUTO_UPDATE", "true");
+
+    if let Some(home) = home::home_dir() {
+        cmd.current_dir(home);
+    }
+
+    let out = cmd.output().map_err(Error::Shell)?;
 
     if out.status.success() {
       let stdout = String::from_utf8_lossy(&out.stdout).into_owned();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,13 +36,14 @@ pub fn fix_vars(vars: &[&str]) -> std::result::Result<(), Error> {
 
     let mut cmd = std::process::Command::new(shell);
 
-    cmd.arg("-ilc")
+    cmd
+      .arg("-ilc")
       .arg("echo -n \"_SHELL_ENV_DELIMITER_\"; env; echo -n \"_SHELL_ENV_DELIMITER_\"; exit")
       // Disables Oh My Zsh auto-update thing that can block the process.
       .env("DISABLE_AUTO_UPDATE", "true");
 
     if let Some(home) = home::home_dir() {
-        cmd.current_dir(home);
+      cmd.current_dir(home);
     }
 
     let out = cmd.output().map_err(Error::Shell)?;


### PR DESCRIPTION
Consider this scenario:
```bash
# script.sh
export ABC=2

# .zshrc
source script.sh
```

The `ABC` variable will not be set because the shell executes under a different folder (I think it's `/Applications`?).

However, if I have `source /Users/myusername/script.sh` it works.

---

So this PR basically sets Home as the CWD for the command. It works for me and I couldn't think of any negative aspects of doing this.