### PR TITLE
feat: add Windows PATH inheritance bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # fix-path-env-rs
 ![Test](https://github.com/tauri-apps/fix-path-env-rs/workflows/Test/badge.svg)
 
-A Rust crate to fix the `PATH` environment variable on macOS and Linux when running a GUI app.
+A Rust crate to fix the `PATH` environment variable on Windows, macOS, and Linux when running a GUI app.
 
-GUI apps on macOS and Linux do not inherit the `$PATH` from your shell dotfiles (*.bashrc, .bash_profile, .zshrc, etc*).
+GUI apps have different PATH inheritance issues on different platforms:
+- **Windows**: `std::process::Command` sometimes doesn't inherit the parent process's PATH
+- **macOS/Linux**: GUI apps don't inherit the `$PATH` from your shell dotfiles (*.bashrc, .bash_profile, .zshrc, etc*)
 
 ## Installation
 Please note, below in the dependencies you can also lock to a revision/tag in the `Cargo.toml`.
@@ -20,6 +22,14 @@ fn main() {
     let _ = fix_path_env::fix(); // <---- Add this
 }
 ```
+
+## Platform Behavior
+
+### Windows
+Fixes the PATH inheritance bug in `std::process::Command` where child processes sometimes can't find executables that are in PATH. This is a known issue where GUI applications on Windows don't properly inherit environment variables from their parent process.
+
+### macOS & Linux
+Reads your shell configuration (`.zshrc`, `.bash_profile`, etc.) to get the PATH that would be available in your terminal, then applies it to the current process. This ensures GUI applications can find commands installed via Homebrew, package managers, or manually added to your shell PATH.
 
 # License
 MIT / Apache-2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub fn fix_all_vars() -> std::result::Result<(), Error> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  
+
   #[cfg(windows)]
   use std::env;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,21 @@ pub enum Error {
 ///
 /// ## Platform-specific
 ///
-/// - **Windows**: Does nothing as the environment variables are already set.
+/// - **Windows**: Refreshes environment variables to fix PATH inheritance bug
+///   in std::process::Command where GUI apps don't properly inherit parent PATH
+/// - **macOS/Linux**: Reads shell configuration from login shell
 pub fn fix_vars(vars: &[&str]) -> std::result::Result<(), Error> {
   #[cfg(windows)]
   {
-    let _ = vars;
-    #[allow(clippy::needless_return)]
-    return Ok(());
+    // On Windows, there's a known bug where std::process::Command sometimes
+    // doesn't properly inherit the parent process's environment variables.
+    // By explicitly re-setting them, we force Command to use the current values.
+    for &var in vars {
+      if let Ok(value) = std::env::var(var) {
+        std::env::set_var(var, value);
+      }
+    }
+    Ok(())
   }
   #[cfg(not(windows))]
   {
@@ -78,7 +86,8 @@ pub fn fix_vars(vars: &[&str]) -> std::result::Result<(), Error> {
 ///
 /// ## Platform-specific
 ///
-/// - **Windows**: Does nothing as the environment variables are already set.
+/// - **Windows**: Refreshes PATH to fix inheritance bug in std::process::Command
+/// - **macOS/Linux**: Reads PATH from shell configuration
 pub fn fix() -> std::result::Result<(), Error> {
   fix_vars(&["PATH"])
 }
@@ -87,7 +96,62 @@ pub fn fix() -> std::result::Result<(), Error> {
 ///
 /// ## Platform-specific
 ///
-/// - **Windows**: Does nothing as the environment variables are already set.
+/// - **Windows**: Refreshes all environment variables to fix inheritance bug
+/// - **macOS/Linux**: Reads all environment variables from shell configuration
 pub fn fix_all_vars() -> std::result::Result<(), Error> {
   fix_vars(&[])
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  
+  #[cfg(windows)]
+  use std::env;
+
+  #[test]
+  fn test_fix_returns_ok() {
+    // The fix function should always return Ok on all platforms
+    assert!(fix().is_ok());
+  }
+
+  #[test]
+  fn test_fix_vars_returns_ok() {
+    // The fix_vars function should always return Ok on all platforms
+    assert!(fix_vars(&["PATH"]).is_ok());
+  }
+
+  #[test]
+  fn test_fix_all_vars_returns_ok() {
+    // The fix_all_vars function should always return Ok on all platforms
+    assert!(fix_all_vars().is_ok());
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn test_windows_path_preservation() {
+    // On Windows, PATH should exist and be preserved after fix
+    let original_path = env::var("PATH").expect("PATH should exist on Windows");
+    assert!(fix().is_ok());
+    let after_path = env::var("PATH").expect("PATH should still exist after fix");
+    assert_eq!(original_path, after_path);
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn test_windows_custom_var_setting() {
+    // Test that custom variables are properly refreshed on Windows
+    env::set_var("TEST_VAR_FIX_PATH", "test_value");
+    assert!(fix_vars(&["TEST_VAR_FIX_PATH"]).is_ok());
+    assert_eq!(env::var("TEST_VAR_FIX_PATH").unwrap(), "test_value");
+    env::remove_var("TEST_VAR_FIX_PATH");
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn test_windows_nonexistent_var() {
+    // Test that non-existent variables don't cause errors on Windows
+    env::remove_var("NONEXISTENT_VAR_FIX_PATH");
+    assert!(fix_vars(&["NONEXISTENT_VAR_FIX_PATH"]).is_ok());
+  }
 }


### PR DESCRIPTION
Replace Windows no-op implementation with PATH refresh fix for `std::process::Command` inheritance bug.

## Problem
On Windows, there's a documented bug where `std::process::Command` sometimes doesn't properly inherit the parent process's PATH environment variable. This causes external commands to fail in GUI applications even when they're correctly installed and available.

The current implementation is a no-op on Windows:
```rust
#[cfg(windows)]
{
  let _ = vars;
  return Ok(());
}
```

## Solution
Implement the documented workaround: read environment variables and re-set them to the same values. This forces `std::process::Command` to refresh its view of the environment.

```rust
#[cfg(windows)]
{
  for &var in vars {
    if let Ok(value) = std::env::var(var) {
      std::env::set_var(var, value);
    }
  }
  Ok(())
}
```

## References
This implements the same fix used successfully in Whispering (see [this issue](https://github.com/epicenter-so/epicenter/issues/674) and [this pull request](https://github.com/epicenter-so/epicenter/pull/686)), a Tauri application that resolves FFmpeg PATH issues on Windows.